### PR TITLE
Allow non F# union-types to be used as messages

### DIFF
--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -63,8 +63,12 @@ module Program =
     open FSharp.Reflection
 
     let inline private duName (x:'a) =
-        match FSharpValue.GetUnionFields(x, typeof<'a>) with
-        | case, _ -> case.Name
+        let t = typeof<'a>
+        if (isNull t?cases)
+        then "not-a-f#-union"
+        else
+            match FSharpValue.GetUnionFields(x, t) with
+            | case, _ -> case.Name
 
     let inline private getCase<'msg> (cmd: 'msg) : obj =
         createObj ["type" ==> duName cmd


### PR DESCRIPTION
fixes https://github.com/elmish/debugger/issues/20

Actually, I think this should have created problems for anyone not using F#-unions. I think we should add a test for this case.
Are there already tests in this library?