### PR TITLE
Encode 'msg when using "Remote" and "Secure" debugger

### DIFF
--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -37,8 +37,8 @@ module Debugger =
 
         match opt with
         | ViaExtension -> { fallback with remote = false; hostname = "localhost"; port = 8000; secure = false }
-        | Remote (address,port) -> { fallback with hostname = address; port = port; secure = false; getActionType = None }
-        | Secure (address,port) -> { fallback with hostname = address; port = port; getActionType = None }
+        | Remote (address,port) -> { fallback with hostname = address; port = port; secure = false }
+        | Secure (address,port) -> { fallback with hostname = address; port = port }
         |> connectViaExtension
 
     type Send<'msg,'model> = 'msg*'model -> unit


### PR DESCRIPTION
This fixes #33

From reading the [remotedev source code](https://github.com/zalmoxisus/remotedev/blob/f8256d934316b37a94cd24870fc1d3efcbe7d0b9/src/devTools.js#L66) there is no reason that encoding the message should be disabled.

So this change just uses the 'msg auto encoder.