### PR TITLE
Allow using Redux Devtools directly without remotedev

### DIFF
--- a/src/Fable.Import.RemoteDev.fs
+++ b/src/Fable.Import.RemoteDev.fs
@@ -1,6 +1,5 @@
 namespace Fable.Import
 
-open System
 open Fable.Core
 
 module RemoteDev =
@@ -21,8 +20,7 @@ module RemoteDev =
         let JumpToAction = "JUMP_TO_ACTION"
 
     type Options<'msg> =
-        { remote : bool
-          port : int
+        { port : int
           hostname : string
           secure : bool
           getActionType : ('msg->obj) option }
@@ -61,7 +59,7 @@ module RemoteDev =
     [<Import("connect","remotedev")>]
     let connect<'msg> (options: Options<'msg>): Connection = jsNative
 
-    [<Import("connectViaExtension","remotedev")>]
+    [<Emit("window.__REDUX_DEVTOOLS_EXTENSION__.connect($0)")>]
     let connectViaExtension<'msg> (options: Options<'msg>): Connection = jsNative
 
     [<Import("extractState","remotedev")>]

--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -1,6 +1,5 @@
 namespace Elmish.Debug
 
-open Fable.Import
 open Fable.Import.RemoteDev
 open Fable.Core.JsInterop
 open Fable.Core
@@ -8,8 +7,6 @@ open Thoth.Json
 
 [<RequireQualifiedAccess>]
 module Debugger =
-    open FSharp.Reflection
-
     let showError (msgs: obj list) = JS.console.error("[ELMISH DEBUGGER]", List.toArray msgs)
     let showWarning (msgs: obj list) = JS.console.warn("[ELMISH DEBUGGER]", List.toArray msgs)
 
@@ -37,17 +34,21 @@ module Debugger =
             else
                 makeMsgObj("NOT-AN-F#-UNION", x)
 
-        let fallback = { Options.remote = true
-                         hostname = "remotedev.io"
+        let fallback = { hostname = "remotedev.io"
                          port = 443
                          secure = true
                          getActionType = Some getCase }
 
         match opt with
-        | ViaExtension -> { fallback with remote = false; hostname = "localhost"; port = 8000; secure = false }
-        | Remote (address,port) -> { fallback with hostname = address; port = port; secure = false }
-        | Secure (address,port) -> { fallback with hostname = address; port = port }
-        |> connectViaExtension
+        | ViaExtension ->
+            { fallback with hostname = "localhost"; port = 8000; secure = false }
+            |> connectViaExtension
+        | Remote (address,port) ->
+            { fallback with hostname = address; port = port; secure = false }
+            |> connect
+        | Secure (address,port) ->
+            { fallback with hostname = address; port = port }
+            |> connect
 
     type Send<'msg,'model> = 'msg*'model -> unit
 


### PR DESCRIPTION
Currently, remotedev is needed in all cases, even if you only want to use Redux Devtools. This is only a problem because remotedev hasn't seen updates in a few years now, leading to a few security alerts every now and again.

Furthermore, if there are no Redux Devtools installed in the browser, it automatically defaults to "localhost:8000" which leads to a lot of console errors without the Extension. (See https://github.com/zalmoxisus/remotedev/blob/f8256d934316b37a94cd24870fc1d3efcbe7d0b9/src/devTools.js#L126)

This fixes both of those problems by making the "Redux DevTools Extension" <> "Remotedev" decision before actually calling into the remotedev package.