### PR TITLE
Pin the dependencies to versions compatible with .NET 6

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -1,10 +1,10 @@
 #!/usr/bin/env -S dotnet fsi
-#r "nuget: Fake.Core.Target"
-#r "nuget: Fake.IO.FileSystem"
-#r "nuget: Fake.DotNet.Cli"
-#r "nuget: Fake.Core.Target"
-#r "nuget: Fake.Core.ReleaseNotes"
-#r "nuget: Fake.Tools.Git"
+#r "nuget: Fake.Core.Target, 5.23.1"
+#r "nuget: Fake.IO.FileSystem, 5.23.1"
+#r "nuget: Fake.DotNet.Cli, 5.23.1"
+#r "nuget: Fake.Core.Target, 5.23.1"
+#r "nuget: Fake.Core.ReleaseNotes, 5.23.1"
+#r "nuget: Fake.Tools.Git, 5.23.1"
 
 #nowarn "52"
 


### PR DESCRIPTION
Fixes the CI worfklow