### PR TITLE
Decouple remotedev from the code that doesn't need it

### DIFF
--- a/src/Fable.Import.RemoteDev.fs
+++ b/src/Fable.Import.RemoteDev.fs
@@ -62,5 +62,8 @@ module RemoteDev =
     [<Emit("window.__REDUX_DEVTOOLS_EXTENSION__.connect($0)")>]
     let connectViaExtension<'msg> (options: Options<'msg>): Connection = jsNative
 
-    [<Import("extractState","remotedev")>]
-    let extractState (x: obj): obj = jsNative
+    [<Import("parse","jsan")>]
+    let parse (x: string): obj = jsNative
+
+    let extractState message =
+        parse message.state

--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -11,44 +11,44 @@ module Debugger =
     let showWarning (msgs: obj list) = JS.console.warn("[ELMISH DEBUGGER]", List.toArray msgs)
 
     type ConnectionOptions =
-        | ViaExtension
         | Remote of address:string * port:int
         | Secure of address:string * port:int
 
+    let makeMsgObj (case, fields) =
+        createObj ["type" ==> case; "msg" ==> fields]
+
+    let getCase (x: obj) =
+        if Reflection.isUnion x then
+            let rec getCaseName acc (x: obj) =
+                let acc = (Reflection.getCaseName x)::acc
+                let fields = Reflection.getCaseFields x
+                if fields.Length = 1 && Reflection.isUnion fields.[0] then
+                    getCaseName acc fields.[0]
+                else
+                    // Case names are intentionally left reverted so we see
+                    // the most meaningfull message first
+                    makeMsgObj(acc |> String.concat "/", fields)
+            getCaseName [] x
+        else
+            makeMsgObj("NOT-AN-F#-UNION", x)
+
+    let fallback = { hostname = "remotedev.io"
+                     port = 443
+                     secure = true
+                     getActionType = Some getCase }
+
     let inline connect<'msg> opt =
-        let makeMsgObj (case, fields) =
-            createObj ["type" ==> case; "msg" ==> fields]
-
-        let getCase (x: obj) =
-            if Reflection.isUnion x then
-                let rec getCaseName acc (x: obj) =
-                    let acc = (Reflection.getCaseName x)::acc
-                    let fields = Reflection.getCaseFields x
-                    if fields.Length = 1 && Reflection.isUnion fields.[0] then
-                        getCaseName acc fields.[0]
-                    else
-                        // Case names are intentionally left reverted so we see
-                        // the most meaningfull message first
-                        makeMsgObj(acc |> String.concat "/", fields)
-                getCaseName [] x
-            else
-                makeMsgObj("NOT-AN-F#-UNION", x)
-
-        let fallback = { hostname = "remotedev.io"
-                         port = 443
-                         secure = true
-                         getActionType = Some getCase }
-
         match opt with
-        | ViaExtension ->
-            { fallback with hostname = "localhost"; port = 8000; secure = false }
-            |> connectViaExtension
         | Remote (address,port) ->
             { fallback with hostname = address; port = port; secure = false }
             |> connect
         | Secure (address,port) ->
             { fallback with hostname = address; port = port }
             |> connect
+
+    let inline connectViaExtension<'msg> =
+        { fallback with hostname = "localhost"; port = 8000; secure = false }
+        |> connectViaExtension
 
     type Send<'msg,'model> = 'msg*'model -> unit
 
@@ -138,7 +138,7 @@ module Program =
 
     let inline withDebuggerCoders (encoder: Encoder<'model>) (decoder: Decoder<'model>) program : Program<'a,'model,'msg,'view> =
         let deflater, inflater = getTransformersWith encoder decoder
-        let connection = Debugger.connect<'msg> Debugger.ViaExtension
+        let connection = Debugger.connectViaExtension<'msg>
         withDebuggerUsing deflater inflater connection program
 
     let inline withDebuggerAt options program : Program<'a,'model,'msg,'view> =
@@ -153,7 +153,7 @@ module Program =
     let inline withDebugger (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
         try
             let deflater, inflater = getTransformers<'model>()
-            let connection = Debugger.connect<'msg> Debugger.ViaExtension
+            let connection = Debugger.connectViaExtension<'msg>
             withDebuggerUsing deflater inflater connection program
         with ex ->
             Debugger.showError ["Unable to connect to the monitor, continuing w/o debugger"; ex.Message]


### PR DESCRIPTION
As explained in #72, due to security concerns it is desirable to be able to use the Elmish Debugger without installing the JS library remotedev.

This PR provides a solution for local use with the browser extension Redux DevTools. The decoupling from remotedev results from the following changes:

- The function `extractState` from remotedev is now implemented using Fable, which calls the function `parse` from the JS library jsan.
- The function `Debugger.connect` is now only a wrapper for the function `connect` of remotedev. In order to connect to the browser extension there is now the function `Debugger.connectViaExtension`.

For reference, the original `extractState` is [implemented](https://github.com/zalmoxisus/remotedev/blob/f8256d934316b37a94cd24870fc1d3efcbe7d0b9/src/devTools.js#L10) as follows:

```js
export function extractState(message) {
  if (!message || !message.state) return undefined;
  if (typeof message.state === 'string') return parse(message.state);
  return message.state;
}
```

The types in the F# code that calls this function make all the input validation unnecessary. Therefore, it can be simplified to just parsing `message.state`.