### PR TITLE
Allow configuring the extension options

### DIFF
--- a/src/Fable.Import.RemoteDev.fs
+++ b/src/Fable.Import.RemoteDev.fs
@@ -25,6 +25,14 @@ module RemoteDev =
           secure : bool
           getActionType : ('msg->obj) option }
 
+    [<Global>]
+    type ExtensionOptions
+        [<ParamObject; Emit("$0")>]
+        (
+            name: string
+        ) =
+        member val name: string = jsNative with get, set
+
     type Action =
         { ``type``: string
           fields : obj array }
@@ -60,7 +68,7 @@ module RemoteDev =
     let connect<'msg> (options: Options<'msg>): Connection = jsNative
 
     [<Emit("window.__REDUX_DEVTOOLS_EXTENSION__.connect($0)")>]
-    let connectViaExtension<'msg> (options: Options<'msg>): Connection = jsNative
+    let connectViaExtension (options: ExtensionOptions): Connection = jsNative
 
     [<Import("parse","jsan")>]
     let parse (x: string): obj = jsNative

--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -46,9 +46,8 @@ module Debugger =
             { fallback with hostname = address; port = port }
             |> connect
 
-    let inline connectViaExtension<'msg> =
-        { fallback with hostname = "localhost"; port = 8000; secure = false }
-        |> connectViaExtension
+    let inline connectViaExtension options =
+        connectViaExtension options
 
     type Send<'msg,'model> = 'msg*'model -> unit
 
@@ -138,7 +137,7 @@ module Program =
 
     let inline withDebuggerCoders (encoder: Encoder<'model>) (decoder: Decoder<'model>) program : Program<'a,'model,'msg,'view> =
         let deflater, inflater = getTransformersWith encoder decoder
-        let connection = Debugger.connectViaExtension<'msg>
+        let connection = Debugger.connectViaExtension createEmpty
         withDebuggerUsing deflater inflater connection program
 
     let inline withDebuggerAt options program : Program<'a,'model,'msg,'view> =
@@ -150,11 +149,14 @@ module Program =
             Debugger.showError ["Unable to connect to the monitor, continuing w/o debugger"; ex.Message]
             program
 
-    let inline withDebugger (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
+    let inline withDebuggerOptions (options: ExtensionOptions) (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
         try
             let deflater, inflater = getTransformers<'model>()
-            let connection = Debugger.connectViaExtension<'msg>
+            let connection = Debugger.connectViaExtension options
             withDebuggerUsing deflater inflater connection program
         with ex ->
             Debugger.showError ["Unable to connect to the monitor, continuing w/o debugger"; ex.Message]
             program
+
+    let inline withDebugger (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
+        withDebuggerOptions createEmpty program


### PR DESCRIPTION
The `connect` method of the browser extension Redux DevTools takes as argument an [options object](https://github.com/reduxjs/redux-devtools/blob/main/extension/docs/API/Arguments.md), which among other things, allows setting the name of the instance shown in the extension. This feature was requested in #58 and is implemented in this PR, which defines:

- The type `ExtensionOptions` for the argument of `connectViaExtension`, which currently only has the field `name`
- The function`withDebuggerOptions`, which calls `connectViaExtension`. It was introduced in order to avoid changing `withDebugger`, which now calls `withDebuggerOptions` passing an empty POJO for the options

Since Fable compiles an F# record to a JS class, `ParamObject` is used to generate a POJO, which is what the `connect` function expects.