### PR TITLE
Added getActionType to ExtensionOptions

### DIFF
--- a/src/Fable.Import.RemoteDev.fs
+++ b/src/Fable.Import.RemoteDev.fs
@@ -29,8 +29,10 @@ module RemoteDev =
     type ExtensionOptions
         [<ParamObject; Emit("$0")>]
         (
-            name: string
+            ?getActionType: obj -> obj,
+            ?name: string
         ) =
+        member val getActionType: obj -> obj = jsNative with get, set
         member val name: string = jsNative with get, set
 
     type Action =

--- a/src/Fable.Import.RemoteDev.fs
+++ b/src/Fable.Import.RemoteDev.fs
@@ -32,8 +32,8 @@ module RemoteDev =
             ?getActionType: obj -> obj,
             ?name: string
         ) =
-        member val getActionType: obj -> obj = jsNative with get, set
-        member val name: string = jsNative with get, set
+        member val getActionType: (obj -> obj) option = jsNative with get, set
+        member val name: string option = jsNative with get, set
 
     type Action =
         { ``type``: string

--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -47,7 +47,7 @@ module Debugger =
             |> connect
 
     let inline connectViaExtension (options: ExtensionOptions) =
-        options.getActionType <- getCase
+        options.getActionType <- Some getCase
         connectViaExtension options
 
     type Send<'msg,'model> = 'msg*'model -> unit

--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -46,7 +46,8 @@ module Debugger =
             { fallback with hostname = address; port = port }
             |> connect
 
-    let inline connectViaExtension options =
+    let inline connectViaExtension (options: ExtensionOptions) =
+        options.getActionType <- getCase
         connectViaExtension options
 
     type Send<'msg,'model> = 'msg*'model -> unit
@@ -137,7 +138,7 @@ module Program =
 
     let inline withDebuggerCoders (encoder: Encoder<'model>) (decoder: Decoder<'model>) program : Program<'a,'model,'msg,'view> =
         let deflater, inflater = getTransformersWith encoder decoder
-        let connection = Debugger.connectViaExtension createEmpty
+        let connection = Debugger.connectViaExtension (new ExtensionOptions())
         withDebuggerUsing deflater inflater connection program
 
     let inline withDebuggerAt options program : Program<'a,'model,'msg,'view> =
@@ -159,4 +160,4 @@ module Program =
             program
 
     let inline withDebugger (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
-        withDebuggerOptions createEmpty program
+        withDebuggerOptions (new ExtensionOptions()) program


### PR DESCRIPTION
This PR fixes a regression in version 4.2.0. In version 4.1.0 the (undocumented) extension option `getActionType` was set to a function that returns the type of the action, which corresponds to the message type in Elmish. Now the actions are correctly displayed in the browser extension.

The parameters of the constructor ExtensionOptions are now optional in order to have the flexibility to configure only certain options.