### PR TITLE
Implement support for actionCreators

### DIFF
--- a/src/Fable.Import.RemoteDev.fs
+++ b/src/Fable.Import.RemoteDev.fs
@@ -26,12 +26,24 @@ module RemoteDev =
           getActionType : ('msg->obj) option }
 
     [<Global>]
+    type ActionCreator
+        [<ParamObject; Emit("$0")>]
+        (
+            args: string[],
+            name: string
+        ) =
+        member val args: string[] = jsNative with get, set
+        member val name: string = jsNative with get, set
+
+    [<Global>]
     type ExtensionOptions
         [<ParamObject; Emit("$0")>]
         (
+            ?actionCreators: ActionCreator[],
             ?getActionType: obj -> obj,
             ?name: string
         ) =
+        member val actionCreators: ActionCreator[] option = jsNative with get, set
         member val getActionType: (obj -> obj) option = jsNative with get, set
         member val name: string option = jsNative with get, set
 

--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -3,6 +3,7 @@ namespace Elmish.Debug
 open Fable.Import.RemoteDev
 open Fable.Core.JsInterop
 open Fable.Core
+open Microsoft.FSharp.Reflection
 open Thoth.Json
 
 [<RequireQualifiedAccess>]
@@ -90,7 +91,11 @@ module Program =
             Debugger.showWarning [er.Message]
             box, fun _ -> failwith "Cannot inflate model"
 
-    let withDebuggerUsing (deflater: 'model->obj) (inflater: obj->'model) (connection:Connection) (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
+    let inline withDebuggerUsing (deflater: 'model->obj) (inflater: obj->'model) (connection:Connection) (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
+        let constructMessage name args : 'msg =
+            let cases = Map.ofSeq [for case in FSharpType.GetUnionCases typeof<'msg> -> case.Name, case]
+            FSharpValue.MakeUnion(cases[name], args) :?> 'msg
+        
         let init userInit a =
             let (model,cmd) = userInit a
             connection.init (deflater model, None)
@@ -103,6 +108,8 @@ module Program =
 
         let sub dispatch =
             function
+            | (msg:Msg) when msg.``type`` = MsgTypes.Action ->
+              dispatch (constructMessage msg.payload?name msg.payload?args)
             | (msg:Msg) when msg.``type`` = MsgTypes.Dispatch ->
                 try
                     match msg.payload.``type`` with

--- a/src/debugger.fs
+++ b/src/debugger.fs
@@ -46,8 +46,15 @@ module Debugger =
             { fallback with hostname = address; port = port }
             |> connect
 
-    let inline connectViaExtension (options: ExtensionOptions) =
+    let inline connectViaExtension<'msg> (options: ExtensionOptions) =
+        let actionCreators =
+            typeof<'msg>
+            |> FSharpType.GetUnionCases
+            |> Array.map (fun case ->
+                new ActionCreator(name = case.Name, args = (case.GetFields() |> Array.map (fun fieldInfo -> fieldInfo.Name))))
+
         options.getActionType <- Some getCase
+        if options.actionCreators.IsNone then options.actionCreators <- Some actionCreators
         connectViaExtension options
 
     type Send<'msg,'model> = 'msg*'model -> unit
@@ -138,7 +145,7 @@ module Program =
 
     let inline withDebuggerCoders (encoder: Encoder<'model>) (decoder: Decoder<'model>) program : Program<'a,'model,'msg,'view> =
         let deflater, inflater = getTransformersWith encoder decoder
-        let connection = Debugger.connectViaExtension (new ExtensionOptions())
+        let connection = Debugger.connectViaExtension<'msg> (new ExtensionOptions())
         withDebuggerUsing deflater inflater connection program
 
     let inline withDebuggerAt options program : Program<'a,'model,'msg,'view> =
@@ -153,7 +160,7 @@ module Program =
     let inline withDebuggerOptions (options: ExtensionOptions) (program : Program<'a,'model,'msg,'view>) : Program<'a,'model,'msg,'view> =
         try
             let deflater, inflater = getTransformers<'model>()
-            let connection = Debugger.connectViaExtension options
+            let connection = Debugger.connectViaExtension<'msg> options
             withDebuggerUsing deflater inflater connection program
         with ex ->
             Debugger.showError ["Unable to connect to the monitor, continuing w/o debugger"; ex.Message]


### PR DESCRIPTION
As discussed in #71 Redux DevTools allows triggering the actions defined in the config parameter `actionCreators`.
This is an array of POJOs with the fields `name` and `args` used for building the UI for triggering the actions. The 
name and the args' values are sent back to the application in a message with the field `type` set to ACTION.

This PR extends Elmish Debugger to:

- Allow configuring the `actionCreators` parameter of the browser extension
- Handle the ACTION message from Redux DevTools

Reflection is used to dynamically populate `actionCreators` with all the actions defined in the application and also to dynamically dispatch the action received from Redux DevTools. Since Fable erases generics at runtime the function `withDebuggerUsing` has to be inlined so that the generics can be resolved at compile time.
